### PR TITLE
Fixes for Waveshare Pico-ResTouch-LCD-3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Emacs backups
+*~
+
+# Byte-compiled / optimized / etc files
+__pycache__
+*.py[cod]

--- a/ili9488.py
+++ b/ili9488.py
@@ -16,7 +16,7 @@ __author__ = 'Isaac'
 from micropython import const
 from time import sleep
 from math import cos, sin, pi, radians
-from sys import implementation
+import sys
 from framebuf import FrameBuffer, RGB565  # type: ignore
 import ustruct  # type: ignore
 
@@ -29,6 +29,10 @@ def color565(r, g, b):
         b (int): Blue value.
     """
     return (r & 0xf8) << 8 | (g & 0xfc) << 3 | b >> 3
+
+def bswap16(x):
+    """Convert between little-endian and big-endian colors (16-bit)."""
+    return (x & 0xff00) >> 8 | (x & 0x00ff) << 8
 
 
 class Display(object):
@@ -52,7 +56,6 @@ class Display(object):
     RDSELFDIAG = const(0x0F)  # Read display self-diagnostic
     INVOFF = const(0x20)  # Display inversion off
     INVON = const(0x21)  # Display inversion on
-    GAMMASET = const(0x26)  # Gamma set
     DISPLAY_OFF = const(0x28)  # Display off
     DISPLAY_ON = const(0x29)  # Display on
     SET_COLUMN = const(0x2A)  # Column address set
@@ -63,7 +66,7 @@ class Display(object):
     VSCRDEF = const(0x33)  # Vertical scrolling definition
     MADCTL = const(0x36)  # Memory access control
     VSCRSADD = const(0x37)  # Vertical scrolling start address
-    PIXFMT = const(0x3A)  # COLMOD: Pixel format set
+    PIXFMT = const(0x3A)  # COLMOD: Set pixel format
     WRITE_DISPLAY_BRIGHTNESS = const(0x51)  # Brightness hardware dependent!
     READ_DISPLAY_BRIGHTNESS = const(0x52)
     WRITE_CTRL_DISPLAY = const(0x53)
@@ -79,22 +82,22 @@ class Display(object):
     DFUNCTR = const(0xB6)  # Display function control
     PWCTR1 = const(0xC0)  # Power control 1
     PWCTR2 = const(0xC1)  # Power control 2
-    PWCTR3 = const(0xC2)  # Power control 2
-    PWCTRA = const(0xCB)  # Power control A
-    PWCTRB = const(0xCF)  # Power control B
+    PWCTR3 = const(0xC2)  # Power control 3
+    PWCTR4 = const(0xCB)  # Power control 4
+    PWCTR5 = const(0xCF)  # Power control 5
     VMCTR1 = const(0xC5)  # VCOM control 1
-    VMCTR2 = const(0xC7)  # VCOM control 2
-    RDID1 = const(0xDA)  # Read ID 1
-    RDID2 = const(0xDB)  # Read ID 2
-    RDID3 = const(0xDC)  # Read ID 3
-    RDID4 = const(0xDD)  # Read ID 4
+    CABCTR1 = const(0xC6)  # CABC control 1
+    CABCTR2 = const(0xC8)  # CABC control 2
+    CABCTR3 = const(0xC9)  # CABC control 3
+    CABCTR4 = const(0xCA)  # CABC control 4
+    CABCTR5 = const(0xCB)  # CABC control 5
+    CABCTR6 = const(0xCC)  # CABC control 6
+    CABCTR7 = const(0xCD)  # CABC control 7
+    CABCTR8 = const(0xCE)  # CABC control 8
+    CABCTR9 = const(0xCF)  # CABC control 9
+    RDID4 = const(0xD3)  # Read ID 4
     GMCTRP1 = const(0xE0)  # Positive gamma correction
     GMCTRN1 = const(0xE1)  # Negative gamma correction
-    DTCA = const(0xE8)  # Driver timing control A
-    DTCB = const(0xEA)  # Driver timing control B
-    POSC = const(0xED)  # Power on sequence control
-    ENABLE3G = const(0xF2)  # Enable 3 gamma control
-    PUMPRC = const(0xF7)  # Pump ratio control
 
     ROTATE = {
         0: 0x88,
@@ -127,7 +130,7 @@ class Display(object):
             self.rotation = self.ROTATE[rotation]
 
         # Initialize GPIO pins and set implementation specific methods
-        if implementation.name == 'circuitpython':
+        if sys.implementation.name == 'circuitpython':
             self.cs.switch_to_output(value=True)
             self.dc.switch_to_output(value=False)
             self.rst.switch_to_output(value=True)
@@ -141,12 +144,19 @@ class Display(object):
             self.reset = self.reset_mpy
             self.write_cmd = self.write_cmd_mpy
             self.write_data = self.write_data_mpy
+        # Most of our processors are little-endian and ILI colors need to be
+        # big-endian (but test sys.byteorder to be proactive for other CPUS)
+        if sys.byteorder == 'little':
+            self.swap_color = bswap16
+        else:
+            self.swap_color = lambda x: x        # no-op identity function
+
         self.reset()
         # Send initialization commands
         self.write_cmd(self.SWRESET)  # Software reset
-        sleep(.1)
+        sleep(.120) # requirement is 120ms between SWRESET and SLPOUT below
 
-        # revised minimal set of initialization commands for ili9488
+        # revised minimal set of initialization commands for ILI9488
         self.write_cmd(self.INVON)  # Inverse on
         self.write_cmd(self.PWCTR3, 0x33)  # Pwr ctrl 3
         self.write_cmd(self.PIXFMT, 0x55)  # pixel format
@@ -154,9 +164,12 @@ class Display(object):
         self.write_cmd(self.MADCTL, self.rotation)  # Memory access ctrl
 
         self.write_cmd(self.SLPOUT)  # Exit sleep
-        sleep(.120)                  # 120ms used in some references (vs 100ms)
+        # Actually, the data sheet says 120ms between a SLPIN/SLPOUT pairs.
+        # But after a SLPOUT, it says only 5ms required
+        #sleep(.1)
+        sleep(0.005)
         self.write_cmd(self.DISPLAY_ON)  # Display on
-        sleep(.1)
+        #sleep(.1)   # not required
         self.clear()
    
     def block(self, x0, y0, x1, y1, data):
@@ -562,18 +575,14 @@ class Display(object):
         # Confirm coordinates in boundary
         if self.is_off_grid(x, y, x + 7, y + 7):
             return
-        # Rearrange color
-        r = (color & 0xF800) >> 8
-        g = (color & 0x07E0) >> 3
-        b = (color & 0x1F) << 3
+        # FrameBuffer stores colors in native byte-order while the ILI9488
+        # wants them in big-endian order.  Hence, we use self.swap_color()
+        # to rearrange the fg/bg colors before we write them to the FB
         buf = bytearray(w * 16)
         fbuf = FrameBuffer(buf, w, h, RGB565)
         if background != 0:
-            bg_r = (background & 0xF800) >> 8
-            bg_g = (background & 0x07E0) >> 3
-            bg_b = (background & 0x1F) << 3
-            fbuf.fill(color565(bg_b, bg_r, bg_g))
-        fbuf.text(text, 0, 0, color565(b, r, g))
+            fbuf.fill(self.swap_color(background))
+        fbuf.text(text, 0, 0, self.swap_color(color))
         if rotate == 0:
             self.block(x, y, x + w - 1, y + (h - 1), buf)
         elif rotate == 90:

--- a/picotest.py
+++ b/picotest.py
@@ -1,11 +1,16 @@
-"""ILI9488 demo (w/ fonts) on RPi Pico with Waveshare Pico-ResTouch-LCD-3.5."""
-from ili9488 import Display, color565
+##
+## ILI9488 demos on RPi Pico with Waveshare Pico-ResTouch-LCD-3.5.
+##
+
+from ili9488 import Display, color565, bswap16
 from machine import Pin, SPI
 from xglcd_font import XglcdFont
+import framebuf
+import array
 import time
 
-def test():
-    """Test code."""
+def test_1():
+    """Original main.py test with xglcd fonts + some rectangles."""
     # Baud rate of 60000000 seems about the max
     spi = SPI(1, baudrate=60000000, sck=Pin(10), mosi=Pin(11), miso=Pin(12))
     display = Display(spi, dc=Pin(8), cs=Pin(9), rst=Pin(15),
@@ -25,16 +30,116 @@ def test():
     arcadepix = XglcdFont('fonts/ArcadePix9x11.c', 9, 11)
     print('Loading bally')
     bally = XglcdFont('fonts/Bally7x9.c', 7, 9)
-    time.sleep(1)
 
     display.draw_text(0, 10, "This's a small test!", arcadepix, 
                       color565(255, 255, 255))
     display.draw_text(0, 100, 'Bally 7x9', bally, color565(0, 255, 0))
     display.draw_text8x8(0, 150, 'Built-in 8x8', color565(0, 255, 255))
-
     display.draw_line(160, 0, 160, 319, color565(0, 0, 255))
-    # for i in range(320):
-    #     display.draw_pixel(160, i, color565(0, 0, 255))
 
 
-test()
+def test_2():
+    """Test a portrait-style orientation."""
+    spi = SPI(1, baudrate=60000000, sck=Pin(10), mosi=Pin(11), miso=Pin(12))
+    display = Display(spi, dc=Pin(8), cs=Pin(9), rst=Pin(15),
+                      width=320, height=480, rotation=0)
+
+    display.clear()
+    display.draw_rectangle(70, 0, 50, 50, 0xffff)
+    display.fill_rectangle(0, 0, 50, 50, color565(255, 0, 0))
+    display.draw_text8x8(0, 80, 'Waveshare Test!', color565(255, 255, 0))
+    display.draw_hline(0, 90, 240, color565(0, 255, 0))
+    display.draw_vline(60, 90, 70, color565(0, 0, 255))
+
+
+def test_3():
+    """This (mostly) replicates the pattern in main_3inch5.py from Waveshare."""
+    spi = SPI(1, baudrate=60000000, sck=Pin(10), mosi=Pin(11), miso=Pin(12))
+    display = Display(spi, dc=Pin(8), cs=Pin(9), rst=Pin(15),
+                      width=480, height=320, rotation=90)
+
+    display.clear(0xffff)
+    display.fill_rectangle(140, 5, 200, 30, color565(255, 0, 0))
+    display.draw_text8x8(170, 17, "Raspberry Pi Pico", 0xffff,
+                         background=0xf800)
+    display.draw_text8x8(170, 57, "3.5' IPS LCD TEST", 0x0, background=0xffff)
+    disp_color = 0x001F
+    for i in range(0,12):
+        display.fill_rectangle(i*30+60, 100, 30, 50, disp_color)
+        disp_color = disp_color << 1
+    display.fill_rectangle(0, 220, 120, 100, color565(255, 0, 255))
+    display.fill_rectangle(120, 220, 120, 100, color565(255, 255, 0))
+    display.fill_rectangle(240, 220, 120, 100, color565(0, 255, 0))
+    display.fill_rectangle(360, 220, 120, 100, color565(0, 255, 255))
+
+
+def test_4():
+    """Left half draws native, while right half draws to FB and block()."""
+    spi = SPI(1, baudrate=60000000, sck=Pin(10), mosi=Pin(11), miso=Pin(12))
+    disp = Display(spi, dc=Pin(8), cs=Pin(9), rst=Pin(15),
+                      width=480, height=320, rotation=90)
+
+    buf = bytearray(240*80*2)
+    fb = framebuf.FrameBuffer(buf, 240, 80, framebuf.RGB565)
+
+    # std colors
+    white = 0xffff
+    black = 0
+    red = color565(255, 0, 0)
+    green = color565(0, 255, 0)
+    magenta = color565(255, 0, 255)
+    cyan = color565(0, 255, 255)
+    yellow = color565(255, 255, 0)
+
+    ## compare native calls on left to FrameBuffer blit on right
+    # 1st quarter
+    disp.fill_rectangle(0, 0, 240, 80, white)
+    disp.fill_rectangle(50, 10, 100, 50, cyan)
+    disp.draw_text8x8(70, 30, 'rect', magenta, background=cyan)
+
+    fb.fill(white)
+    fb.rect(50, 10, 100, 50, bswap16(cyan), True)
+    fb.text('rect', 70, 30, bswap16(magenta))
+    disp.block(240, 0, 479, 79, buf)
+
+    # 2nd quarter
+    disp.draw_ellipse(120, 120, 80, 30, red)
+    disp.draw_text8x8(100, 120, 'ellipse', white)
+
+    fb.fill(black)
+    fb.ellipse(120, 40, 80, 30, bswap16(red))
+    fb.text('ellipse', 100, 40, white)
+    disp.block(240, 80, 479, 159, buf)
+
+    # 3rd quarter
+    disp.fill_rectangle(0, 160, 240, 80, white)
+    disp.fill_polygon(6, 120, 200, 30, green)
+    disp.draw_text8x8(100, 200, 'polygon', black, background=green)
+
+    fb.fill(white)
+    verts = array.array('h', [-20, -25, 20, -25, 30, 0, 20, 25, -20, 25, -30, 0])
+    fb.poly(120, 40, verts, bswap16(green), True)
+    fb.text('polygon', 100, 40, black)
+    disp.block(240, 160, 479, 239, buf)
+
+    # 4th quarter
+    disp.draw_line(0, 240, 239, 319, yellow)
+    disp.draw_line(239, 240, 0, 319, yellow)
+    disp.draw_text8x8(100, 280, 'lines', white)
+
+    fb.fill(black)
+    fb.line(0, 0, 239, 79, bswap16(yellow))
+    fb.line(239, 0, 0, 79, bswap16(yellow))
+    fb.text('lines', 100, 40, white)
+    disp.block(240, 240, 479, 319, buf)
+
+
+if __name__ == '__main__':
+    # spin through all tests (or comment out and just pick one)
+    test_1()
+    time.sleep(5)
+    test_2()
+    time.sleep(5)
+    test_3()
+    time.sleep(5)
+    test_4()

--- a/picotest.py
+++ b/picotest.py
@@ -1,0 +1,40 @@
+"""ILI9488 demo (w/ fonts) on RPi Pico with Waveshare Pico-ResTouch-LCD-3.5."""
+from ili9488 import Display, color565
+from machine import Pin, SPI
+from xglcd_font import XglcdFont
+import time
+
+def test():
+    """Test code."""
+    # Baud rate of 60000000 seems about the max
+    spi = SPI(1, baudrate=60000000, sck=Pin(10), mosi=Pin(11), miso=Pin(12))
+    display = Display(spi, dc=Pin(8), cs=Pin(9), rst=Pin(15),
+                      width=480, height=320, rotation=90)
+
+    display.clear(color565(255,0,0))
+    print('wrote clear RED')
+    time.sleep(1)
+    display.draw_rectangle(100, 100, 100, 100, 0xffff)
+    print('wrote outline WHITE')
+    display.fill_hrect(200, 150, 100, 100, color565(0,255,0))
+    print('wrote hrect GREEN')
+    time.sleep(1)
+
+    print('Loading fonts...')
+    print('Loading arcadepix')
+    arcadepix = XglcdFont('fonts/ArcadePix9x11.c', 9, 11)
+    print('Loading bally')
+    bally = XglcdFont('fonts/Bally7x9.c', 7, 9)
+    time.sleep(1)
+
+    display.draw_text(0, 10, "This's a small test!", arcadepix, 
+                      color565(255, 255, 255))
+    display.draw_text(0, 100, 'Bally 7x9', bally, color565(0, 255, 0))
+    display.draw_text8x8(0, 150, 'Built-in 8x8', color565(0, 255, 255))
+
+    display.draw_line(160, 0, 160, 319, color565(0, 0, 255))
+    # for i in range(320):
+    #     display.draw_pixel(160, i, color565(0, 0, 255))
+
+
+test()


### PR DESCRIPTION
I am working with this display board and the Raspberry Pi Pico:
    https://www.waveshare.com/wiki/Pico-ResTouch-LCD-3.5

I tried your driver from the main branch in Github, but it didn't work for me.  The main problem was that writing command parameters with SPI.write() only works if I write a single byte per write() call.  I don't have a clear explanation for this, but looping one write() call per byte seems to be a safe workaround.

In addition, I found a bunch of opcodes that carried over from the source driver for ILI93xx chips but do not appear in the ILI9488 data sheet.  I updated these codes based on the data sheet (although I didn't include everything in the data sheet).  Similarly, the initialization code contained commands or parameters that didn't make sense based on the ILI9488 data sheet.  I reduced these to a fairly minimal set that works OK for me.

Finally, I found that the code for draw_text8x8() had a bug with foreground and background colors.  It turns out that any code using Micropython's FrameBuffer and the block() method to copy the FB's backing buffer to the ILI9488 is problematic.  This is because FrameBuffers store the 16-bit colors in native byte-order (which is little-endian) while the ILI9488 expects colors to be big-endian.  I couldn't find any code or hooks in FrameBuffer to deal with this, so I added code to the driver for byte-swapping and then flip the color value before writing into the FrameBuffer.

I don't know how much you are actively maintaining/supporting your driver, but I might as well send you these fixes if you want to use them.  I'm fine with using my private version for my purposes, so no urgency to merge this from my end.

Thanks,

Tom Pavel
